### PR TITLE
Add user namespace

### DIFF
--- a/own3d-ext.d.ts
+++ b/own3d-ext.d.ts
@@ -75,6 +75,9 @@ declare namespace OWN3D.ext {
          */
         function isEnabled(feature: string): boolean
 
+        /**
+         * Returns a list of all available feature flags.
+         */
         function getFeatures(): string[]
     }
 

--- a/own3d-ext.d.ts
+++ b/own3d-ext.d.ts
@@ -42,6 +42,43 @@ declare namespace OWN3D.ext {
     }
 
     /**
+     * The user namespace provides information about the current user interacting with the extension.
+     */
+    namespace user {
+        /**
+         * The user's ID.
+         */
+        const id: string | null
+
+        /**
+         * The user's extension scopes.
+         */
+        const scopes: string[]
+
+        /**
+         * The user's pro subscription status.
+         */
+        const pro_subscription: ProSubscription | null
+
+        /**
+         * The user's extension token.
+         */
+        const token: string
+    }
+
+    /**
+     * The feature-flag namespace provides information about the current global feature flags.
+     */
+    namespace features {
+        /**
+         * Whether the current feature flag is enabled.
+         */
+        function isEnabled(feature: string): boolean
+
+        function getFeatures(): string[]
+    }
+
+    /**
      * Register a callback to be invoked when the extension is authorized.
      */
     function onAuthorized(authCallback: (auth: Authorized) => void): void;
@@ -54,10 +91,16 @@ declare namespace OWN3D.ext {
     ): void;
 }
 
+export interface ProSubscription {
+    // tbd definition
+    features: string[];
+}
+
 export interface Authorized {
     client_id: string;
     channel_id: string;
     user_id: string;
+    scopes: string[];
     token: string;
 }
 


### PR DESCRIPTION
This adds the user state to app extensions, the most prominent feature is the `ProSubscription` state, which allows 3P to check for specific plan features.

@StefanEnsmann We need to talk about how we want to handle opt-in's & optional `features` for pro subscriptions.